### PR TITLE
Add missing module declaration after namespace for #1

### DIFF
--- a/src/jsgraphs.d.ts
+++ b/src/jsgraphs.d.ts
@@ -250,3 +250,7 @@ declare namespace JsGraphs {
         minCut(G: FlowNetwork): FlowEdge[];
     }
 }
+
+declare module "js-graph-algorithms" {
+  export = JsGraphs;
+}


### PR DESCRIPTION
This was inadvertently removed in 5bc6d653f13fc754e5318ec74612f3b951470604.

This time, I have double checked that the declaration is functional from TypeScript. Sorry about the mix-up!